### PR TITLE
enabled to attach image

### DIFF
--- a/alg/dayzero_gmail.py
+++ b/alg/dayzero_gmail.py
@@ -18,12 +18,17 @@ class DayZeroGmail:
         msg['From'] = self.mail_address
         msg['To'] = ', '.join(recipients)
         msg['Date'] = formatdate()
-        text = MIMEText(body)
-        msg.attach(text)
         if img:
             image_data = open(img, 'rb').read()
             image = MIMEImage(image_data, name=os.path.basename(img))
+            image.add_header('Content-ID', '<image>')
             msg.attach(image)
+            body = '<br> <img src="cid:image"> </br><div>{}</div>'.format(body)
+            text = MIMEText(body, 'html')
+
+        else:
+            text = MIMEText(body)
+        msg.attach(text)
 
         smtpobj = smtplib.SMTP_SSL('smtp.gmail.com', 465, timeout=10)
         smtpobj.login(self.mail_address, os.getenv('PASSWORD'))

--- a/alg/matching_notifier.py
+++ b/alg/matching_notifier.py
@@ -9,7 +9,7 @@ class MatchingNotifier:
     def match(self, profiles, times, categories):
         recipient_emails = [p['user']['email'] for p in profiles]
         subject = "You've matched!"
-        self.email.send(recipient_emails, subject, self.matching_message(profiles, times, categories))
+        self.email.send(recipient_emails, subject, self.matching_message(profiles, times, categories), "logo.png")
 
     def matching_message(self, profiles, times, categories):
         # Please feel free to change the content of message using the information in profiles


### PR DESCRIPTION
# Sample Email message

```
gmail = DayZeroGmail()
gmail.send(['foo@example.com', 'bar@example.com'], 'test', 'test')
```

If you want to attach the image 'samle.png' in the DayZero directory you can do like that:

```
gmail = DayZeroGmail()
gmail.send(['liukoki@gmail.com', 'kokir@princeton.edu'], 'test', 'test', 'sample.png')
```

So, if you have any particular image to attach the matching message, please change MatchingNotifier to do so. (Since img argument is optional, the existing MartchingNotifier still work even after accepting this Pull Request.)